### PR TITLE
Ignore container config when running inside a container

### DIFF
--- a/shell-bun.sh
+++ b/shell-bun.sh
@@ -328,7 +328,12 @@ parse_config() {
     if [[ $CLI_CONTAINER_OVERRIDE -eq 1 ]]; then
         CONTAINER_COMMAND="$CLI_CONTAINER_COMMAND"
     else
-        CONTAINER_COMMAND="$CONFIG_CONTAINER_COMMAND"
+        if [[ -f /run/.containerenv && -n "$CONFIG_CONTAINER_COMMAND" ]]; then
+            print_color "$YELLOW" "Detected /run/.containerenv - ignoring configured container command: $CONFIG_CONTAINER_COMMAND"
+            CONTAINER_COMMAND=""
+        else
+            CONTAINER_COMMAND="$CONFIG_CONTAINER_COMMAND"
+        fi
     fi
 
     if [[ ${#APPS[@]} -eq 0 ]]; then

--- a/shell-bun.sh
+++ b/shell-bun.sh
@@ -171,6 +171,7 @@ declare -a EXECUTION_RESULTS=() # Track execution results for log viewing
 GLOBAL_LOG_DIR=""              # Global log directory from config
 CONFIG_CONTAINER_COMMAND=""    # Container command defined in config (if any)
 CONTAINER_COMMAND=""           # Effective container command after CLI overrides
+CONTAINER_ENV_FILE="${SHELL_BUN_CONTAINER_MARKER_FILE:-/run/.containerenv}"
 
 # Helper functions for safely working with SELECTED_ITEMS under set -u and
 # older bash versions where empty array expansions could trigger errors
@@ -328,8 +329,8 @@ parse_config() {
     if [[ $CLI_CONTAINER_OVERRIDE -eq 1 ]]; then
         CONTAINER_COMMAND="$CLI_CONTAINER_COMMAND"
     else
-        if [[ -f /run/.containerenv && -n "$CONFIG_CONTAINER_COMMAND" ]]; then
-            print_color "$YELLOW" "Detected /run/.containerenv - ignoring configured container command: $CONFIG_CONTAINER_COMMAND"
+        if [[ -f "$CONTAINER_ENV_FILE" && -n "$CONFIG_CONTAINER_COMMAND" ]]; then
+            print_color "$YELLOW" "Detected $CONTAINER_ENV_FILE - ignoring configured container command: $CONFIG_CONTAINER_COMMAND"
             CONTAINER_COMMAND=""
         else
             CONTAINER_COMMAND="$CONFIG_CONTAINER_COMMAND"

--- a/tests/test_container_override_flag.bats
+++ b/tests/test_container_override_flag.bats
@@ -4,6 +4,31 @@ setup() {
     export TEST_DIR="$BATS_TEST_DIRNAME"
     export SCRIPT_DIR="$(cd "$TEST_DIR/.." && pwd)"
     export TEST_CONFIG="$TEST_DIR/fixtures/container_override.cfg"
+    export CONTAINER_ENV_PATH="/run/.containerenv"
+    export CONTAINER_ENV_BACKUP="${CONTAINER_ENV_PATH}.bats-backup"
+    export CONTAINER_ENV_CREATED_BY_TEST=0
+}
+
+create_container_env_marker() {
+    if [ -e "$CONTAINER_ENV_PATH" ] && [ ! -e "$CONTAINER_ENV_BACKUP" ]; then
+        mv "$CONTAINER_ENV_PATH" "$CONTAINER_ENV_BACKUP"
+    fi
+    : > "$CONTAINER_ENV_PATH"
+    export CONTAINER_ENV_CREATED_BY_TEST=1
+}
+
+restore_container_env_marker() {
+    if [ "${CONTAINER_ENV_CREATED_BY_TEST:-0}" -eq 1 ]; then
+        if [ -e "$CONTAINER_ENV_BACKUP" ]; then
+            rm -f "$CONTAINER_ENV_PATH"
+            mv "$CONTAINER_ENV_BACKUP" "$CONTAINER_ENV_PATH"
+        else
+            rm -f "$CONTAINER_ENV_PATH"
+        fi
+        export CONTAINER_ENV_CREATED_BY_TEST=0
+    elif [ -e "$CONTAINER_ENV_BACKUP" ]; then
+        mv "$CONTAINER_ENV_BACKUP" "$CONTAINER_ENV_PATH"
+    fi
 }
 
 @test "--container overrides container command from config" {
@@ -42,8 +67,55 @@ CONFIG
     [[ "$output" == *"host-run"* ]]
 }
 
+@test "configured container is ignored when /run/.containerenv exists" {
+    cat > "$TEST_CONFIG" <<'CONFIG'
+# Test config to ensure the configured container command is ignored inside a container
+container=env CONTAINER_SOURCE=config
+
+[TestApp]
+build=echo "container source: ${CONTAINER_SOURCE:-none}"
+CONFIG
+
+    create_container_env_marker
+
+    run "$SCRIPT_DIR/shell-bun.sh" --ci TestApp build "$TEST_CONFIG"
+
+    echo "Exit code: $status"
+    echo "Output: $output"
+
+    restore_container_env_marker
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Detected /run/.containerenv - ignoring configured container command"* ]]
+    [[ "$output" == *"container source: none"* ]]
+}
+
+@test "--container override still applies when /run/.containerenv exists" {
+    cat > "$TEST_CONFIG" <<'CONFIG'
+# Test config to ensure CLI override still wins inside a container
+container=env CONTAINER_SOURCE=config
+
+[TestApp]
+build=echo "container source: ${CONTAINER_SOURCE:-none}"
+CONFIG
+
+    create_container_env_marker
+
+    run "$SCRIPT_DIR/shell-bun.sh" --container "env CONTAINER_SOURCE=cli" --ci TestApp build "$TEST_CONFIG"
+
+    echo "Exit code: $status"
+    echo "Output: $output"
+
+    restore_container_env_marker
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"container source: cli"* ]]
+    [[ "$output" != *"Detected /run/.containerenv - ignoring configured container command"* ]]
+}
+
 teardown() {
     if [ -f "$TEST_CONFIG" ]; then
         rm "$TEST_CONFIG"
     fi
+    restore_container_env_marker
 }


### PR DESCRIPTION
## Summary
- detect when /run/.containerenv is present and ignore the configured container command
- log a warning when the configured container command is skipped
- allow the --container flag to continue overriding the container command

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dc83308a88332bf192ea142dc7aaf)